### PR TITLE
Fix product example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Ndef(\g, {
 	};
 	var n = (1..12); // number of operands
 	var set = n.collect { |i| g.(i) }; // sequence
-	LeakDC.ar(set.reduce(combinator) * (0.01 / n.size)).tanh * 0.1 ! 2 // tanh projects the final output into range
+	var sig = LeakDC.ar(set.reduce(combinator) * (0.01 / n.size)).tanh * 0.1 ! 2; // tanh projects the final output into range
+	sig;
 }).play;
 )
 ```


### PR DESCRIPTION
For some reason the example does not yield any sound.
By sending it into a new variable it generates sound.
Is this a bug in SC or is there something obvious I am missing?
Its not the comment as the following example works w/o issues

```supercollider
(
Ndef(\a, {
	SinOsc.ar(200)*0.2!2 // foo
}).play;
)
```

Edit: BTW: Is there a reason the Issue section is disabled? I think this is a good example why a Issue section is useful as it provides a way for feedback if people struggle with the examples